### PR TITLE
Improve substitution process

### DIFF
--- a/src/example.py
+++ b/src/example.py
@@ -28,7 +28,7 @@ from newton.primitives import Circle, CircularArc, Line, Point, Primitive
 from newton.solver_dense import Solver2DDense
 from newton.solver_sparse import Solver2DSparse
 
-configure_logging(level=logging.INFO)
+configure_logging(level=logging.DEBUG)
 
 PLOT = True
 

--- a/src/example.py
+++ b/src/example.py
@@ -525,12 +525,12 @@ if __name__ == "__main__":
     profiler = Profiler()
     profiler.start()
 
-    # constrain_rectangles()
-    # constrain_parallel_offset()
-    # constrain_underdetermined()
-    # constrain_simple_circle()
-    # constrain_tangent_circle_to_line()
-    # constrain_simple_arc()
+    constrain_rectangles()
+    constrain_parallel_offset()
+    constrain_underdetermined()
+    constrain_simple_circle()
+    constrain_tangent_circle_to_line()
+    constrain_simple_arc()
     constrain_perpendicular_with_shared_vertex()
 
     profiler.stop()

--- a/src/example.py
+++ b/src/example.py
@@ -486,7 +486,7 @@ def constrain_perpendicular_with_shared_vertex():
     l1 = Line(p1, p2, id="L1")
     l2 = Line(p2, p3, id="L2")
 
-    # Ensure segments share the middle vertex
+    # Ensure segments share the middle vertex.
     assert l1.p2 is l2.p1, "Segments must share the middle vertex"
 
     primitives = [p1, p2, p3, l1, l2]
@@ -499,17 +499,17 @@ def constrain_perpendicular_with_shared_vertex():
         LinesPerpendicular(l1, l2),
     ]
 
-    # Plot initial state
+    # Plot initial state.
     if PLOT:
         plt.figure(figsize=(8, 8))
         plot_geometry(primitives, color="red", label="Initial", prime=False)
 
-    # Solve
+    # Solve.
     Solver2D = Solver2DSparse if CONFIG_USE_SPARSE_SOLVE else Solver2DDense
     solver = Solver2D(primitives=primitives, constraints=constraints)
     solver.solve()
 
-    # Plot final state
+    # Plot final state.
     if PLOT:
         plot_geometry(primitives, color="blue", label="Solved", prime=True)
         plt.legend()

--- a/src/example.py
+++ b/src/example.py
@@ -15,6 +15,7 @@ from newton.constraints import (
     LineLineDistance,
     LinesEqualLength,
     LinesParallel,
+    LinesPerpendicular,
     LineTangentToCircle,
     LineVertical,
     PointFixed,
@@ -471,16 +472,66 @@ def test_determinism():
     print(f"Determinism test completed: {n_passed} passed, {n_failed} failed.")
 
 
+def constrain_perpendicular_with_shared_vertex():
+    """
+    Build a simple polyline p1-p2-p3 with two segments:
+    L1 = (p1, p2), L2 = (p2, p3)
+
+    Then constrain L1 perp L2 at the shared vertex p2.
+    """
+    p1 = Point(x=0.0, y=0.0, id="P1")
+    p2 = Point(x=3.2, y=0.7, id="P2")
+    p3 = Point(x=4.8, y=2.1, id="P3")
+
+    l1 = Line(p1, p2, id="L1")
+    l2 = Line(p2, p3, id="L2")
+
+    # Ensure segments share the middle vertex
+    assert l1.p2 is l2.p1, "Segments must share the middle vertex"
+
+    primitives = [p1, p2, p3, l1, l2]
+
+    constraints = [
+        PointFixed(point=p1),
+        LineHorizontal(l1),
+        PointPointXDistance(p1, p2, distance=4.0),
+        PointPointYDistance(p2, p3, distance=3.0),
+        LinesPerpendicular(l1, l2),
+    ]
+
+    # Plot initial state
+    if PLOT:
+        plt.figure(figsize=(8, 8))
+        plot_geometry(primitives, color="red", label="Initial", prime=False)
+
+    # Solve
+    Solver2D = Solver2DSparse if CONFIG_USE_SPARSE_SOLVE else Solver2DDense
+    solver = Solver2D(primitives=primitives, constraints=constraints)
+    solver.solve()
+
+    # Plot final state
+    if PLOT:
+        plot_geometry(primitives, color="blue", label="Solved", prime=True)
+        plt.legend()
+        plt.title("Perpendicular Lines with Shared Vertex")
+        plt.xlabel("X")
+        plt.ylabel("Y")
+        plt.axis("equal")
+        plt.grid(True)
+        plt.show()
+
+
 if __name__ == "__main__":
     profiler = Profiler()
     profiler.start()
 
-    constrain_rectangles()
-    constrain_parallel_offset()
-    constrain_underdetermined()
-    constrain_simple_circle()
-    constrain_tangent_circle_to_line()
-    constrain_simple_arc()
+    # constrain_rectangles()
+    # constrain_parallel_offset()
+    # constrain_underdetermined()
+    # constrain_simple_circle()
+    # constrain_tangent_circle_to_line()
+    # constrain_simple_arc()
+    constrain_perpendicular_with_shared_vertex()
 
     profiler.stop()
     profiler.print()

--- a/src/newton/solver_base.py
+++ b/src/newton/solver_base.py
@@ -2,7 +2,7 @@ import logging
 from abc import ABC, abstractmethod
 from enum import Enum
 from types import ModuleType
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Sequence
 
 import networkx as nx
 import numpy as np
@@ -39,7 +39,9 @@ if logger.isEnabledFor(logging.DEBUG):
 
 
 class Solver2D(ABC):
-    def __init__(self, primitives: List[Primitive], constraints: List[Constraint]):
+    def __init__(
+        self, primitives: Sequence[Primitive], constraints: Sequence[Constraint]
+    ):
         # Build our full set of constraints: this will be the user-defined constraints
         # passed in, plus our definitional constraints from the primitives.
         all_constraints = list(constraints)

--- a/src/newton/solver_base.py
+++ b/src/newton/solver_base.py
@@ -51,8 +51,8 @@ class Solver2D(ABC):
         # Store the primitives and constraints.
         self.primitives = primitives
         self.primitive_map = {p.id: p for p in primitives}
-        self.original_constraints: List[Constraint] = all_constraints
-        self.active_constraints: List[Constraint] = []
+        self.original_constraints: Sequence[Constraint] = all_constraints
+        self.active_constraints: Sequence[Constraint] = []
         self.substitution_map: Dict[str, str] = {}
         self.substitution_stats = SubstitutionStats()
 
@@ -81,7 +81,6 @@ class Solver2D(ABC):
 
         # Use the detailed statistics from the substitution process.
         self.substitution_stats.constraints_eliminated = results.constraints_eliminated
-        self.substitution_stats.constraints_rewritten = results.constraints_rewritten
         self.substitution_stats.constraints_unchanged = results.constraints_unchanged
         self.substitution_stats.variables_eliminated = len(self.substitution_map)
         self.substitution_stats.substitution_map_size = len(self.substitution_map)

--- a/src/newton/solver_base.py
+++ b/src/newton/solver_base.py
@@ -8,6 +8,7 @@ import networkx as nx
 import numpy as np
 from scipy.optimize import OptimizeResult
 
+from newton.backend import Vector
 from newton.constants import CONFIG_USE_SYMB_SUB, NONZERO_RANK_TOLERANCE
 from newton.constraint_validator import ConstraintValidator
 from newton.constraints import (
@@ -280,34 +281,82 @@ class Solver2D(ABC):
                 logger.debug(f"Solving system {i + 1}/{len(constraint_systems)}")
                 self.solve_constraint_system(system)
 
-    def compute_final_variable_values(
+    def build_variable_values_map(
+        self,
+        independent_vars_values: Vector,
+        independent_vars: List[str],
+        initial_values: Dict[str, float],
+        substitution_map: Dict[str, str],
+    ) -> Dict[str, Any]:
+        """
+        Build a complete mapping of all variable IDs to their current values.
+
+        This is used during solve iterations to provide a complete set of variable
+        state vals to constraint evaluation functions.
+
+        Args:
+            independent_vars_values: Current values of variables being solved for.
+            independent_vars: Ordered list of independent variable IDs.
+            initial_values: Initial values for all variables in the system.
+            substitution_map: Map from substituted variables to their root variables.
+
+        Returns:
+            Complete mapping of all variable IDs to their current values.
+        """
+        # Start with the initial state of all variables in the system.
+        variable_values: Dict[str, Any] = dict(initial_values)
+
+        # Create a dictionary of the variables the solver is currently working on.
+        solved_vars = {
+            var_id: independent_vars_values[i]
+            for i, var_id in enumerate(independent_vars)
+        }
+
+        # Update the initial values with the current solved values.
+        variable_values.update(solved_vars)
+
+        # Apply symbolic substitutions to ensure consistency.
+        for var_id, root_id in substitution_map.items():
+            if root_id in variable_values:
+                variable_values[var_id] = variable_values[root_id]
+
+        return variable_values
+
+    def fan_out_solved_variable_values(
         self,
         result: OptimizeResult,
         solved_var_ids: List[str],
         substitution_map: Dict[str, str],
     ) -> Dict[str, float]:
-        # Start with the initial state of all variables in the system.
-        final_variable_values: Dict[str, float] = {}
+        """
+        Distribute the solved variable values through the substitution map, ensuring
+        that all variables, including those eliminated via substitution, are updated and
+        have a type we can work with.
+        """
+        # Get initial values for all variables.
+        initial_values = self.get_initial_values_for_all_variables()
+
+        # Use our consolidated method to build the complete map.
+        # Convert result.x to ensure we have the right array type.
+        final_values = self.build_variable_values_map(
+            result.x, solved_var_ids, initial_values, substitution_map
+        )
+
+        # Ensure all values are Python floats (not JAX tracers or numpy scalars).
+        fanned_out_values = {
+            var_id: float(value) for var_id, value in final_values.items()
+        }
+        return fanned_out_values
+
+    def get_initial_values_for_all_variables(self) -> Dict[str, float]:
+        """
+        Get initial values for all variables across all primitives.
+        """
+        initial_values: Dict[str, float] = {}
         for p in self.primitives:
-            final_variable_values.update(p.get_initial_variable_values())
+            initial_values.update(p.get_initial_variable_values())
 
-        # Get what we actually solved for.
-        solved_values = {var_id: result.x[i] for i, var_id in enumerate(solved_var_ids)}
-
-        # Update the full map with the solved values.
-        final_variable_values.update(solved_values)
-
-        # Handle any symbolic substitutions to ensure all variables are consistent.
-        # (This part handles cases where, e.g., P2.x was substituted by P1.x)
-        all_vars_with_dupes = [v for p in self.primitives for v in p.get_variable_ids()]
-        all_vars = list(dict.fromkeys(all_vars_with_dupes))
-
-        for var_id in all_vars:
-            root = find(var_id, substitution_map)
-            if root in final_variable_values:
-                final_variable_values[var_id] = final_variable_values[root]
-
-        return final_variable_values
+        return initial_values
 
     def assess_solver_result(
         self,

--- a/src/newton/solver_dense.py
+++ b/src/newton/solver_dense.py
@@ -5,7 +5,7 @@
 #   shapes.
 
 import logging
-from typing import Any, Dict, List, Mapping, Sequence
+from typing import Any, Dict, List, Sequence
 
 import jax
 import jax.numpy as jnp
@@ -55,10 +55,8 @@ class Solver2DDense(Solver2D):
             )
             return
 
-        # Build the initial guess array based on this ordered list.
-        initial_values: Dict[str, float] = {}
-        for p in self.primitives:
-            initial_values.update(p.get_initial_variable_values())
+        # Use the consolidated method from the base class.
+        initial_values = self.get_initial_values_for_all_variables()
 
         # Build the initial guess array by looking up the free variables.
         initial_guess = np.array(
@@ -66,28 +64,13 @@ class Solver2DDense(Solver2D):
         )
         jnp_initial_guess = jnp.asarray(initial_guess)
 
-        def build_variable_values_map(
-            independent_vars_values: jnp.ndarray,
-        ) -> Mapping[str, Any]:
-            # The values in solved_vars are JAX tracers, which behave like floats
-            # during JIT compilation.
-            solved_vars = {
-                var_id: independent_vars_values[i]
-                for i, var_id in enumerate(independent_vars)
-            }
-
-            # Unpack the solved variables into the initial values map.
-            variable_values = {**initial_values, **solved_vars}
-
-            # Apply substitutions dynamically.
-            for var_id, root_id in substitution_map.items():
-                if root_id in variable_values:
-                    variable_values[var_id] = variable_values[root_id]
-
-            return variable_values
-
         def residuals_vector(independent_vars_values: jnp.ndarray) -> jnp.ndarray:
-            variable_values = build_variable_values_map(independent_vars_values)
+            variable_values = self.build_variable_values_map(
+                independent_vars_values,
+                independent_vars,
+                initial_values,
+                substitution_map,
+            )
 
             constraint_residuals = jnp.concatenate(
                 [c.get_residual(variable_values) for c in constraints]
@@ -145,9 +128,8 @@ class Solver2DDense(Solver2D):
             verbose=2 if logger.isEnabledFor(logging.DEBUG) else 0,
         )
 
-        # Run checks and update.
-        # Pass the list of variables that were actually solved for.
-        final_variable_values = self.compute_final_variable_values(
+        # Run checks and update using the consolidated method from the base class.
+        final_variable_values = self.fan_out_solved_variable_values(
             result, independent_vars, substitution_map
         )
         self.update_primitives_from_map(final_variable_values)

--- a/src/newton/solver_dense.py
+++ b/src/newton/solver_dense.py
@@ -5,7 +5,7 @@
 #   shapes.
 
 import logging
-from typing import Any, Dict, List, Mapping
+from typing import Any, Dict, List, Mapping, Sequence
 
 import jax
 import jax.numpy as jnp
@@ -21,7 +21,9 @@ from newton.solver_base import SOLVER_CONVERGENCE_TOLERANCE, Solver2D
 
 
 class Solver2DDense(Solver2D):
-    def __init__(self, primitives: List[Primitive], constraints: List[Constraint]):
+    def __init__(
+        self, primitives: Sequence[Primitive], constraints: Sequence[Constraint]
+    ):
         super().__init__(primitives, constraints)
 
         # Handle backend setup.

--- a/src/newton/solver_sparse.py
+++ b/src/newton/solver_sparse.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List, Mapping
+from typing import Any, Dict, List, Mapping, Sequence
 
 import numpy as np
 from scipy.optimize import least_squares
@@ -15,7 +15,9 @@ from newton.symbolic_substitution import find
 
 
 class Solver2DSparse(Solver2D):
-    def __init__(self, primitives: List[Primitive], constraints: List[Constraint]):
+    def __init__(
+        self, primitives: Sequence[Primitive], constraints: Sequence[Constraint]
+    ):
         super().__init__(primitives, constraints)
 
         # Handle backend setup.
@@ -53,7 +55,7 @@ class Solver2DSparse(Solver2D):
 
             i_row += constraint.n_residual_rows
 
-        logger.debug("Jacobian:\n%s", jacobian.toarray())
+        # logger.debug("Jacobian:\n%s", jacobian.toarray())
 
         return jacobian.tocsc()
 

--- a/src/newton/solver_sparse.py
+++ b/src/newton/solver_sparse.py
@@ -84,42 +84,21 @@ class Solver2DSparse(Solver2D):
             return
 
         var_map = {var_id: i for i, var_id in enumerate(independent_vars)}
-        initial_values: Dict[str, float] = {}
 
-        for p in self.primitives:
-            initial_values.update(p.get_initial_variable_values())
-
+        # Use the consolidated method from base class
+        initial_values = self.get_initial_values_for_all_variables()
         initial_guess = np.array(
             [initial_values[var_id] for var_id in independent_vars]
         )
 
-        def build_variable_values_map(
-            independent_vars_values: np.ndarray,
-        ) -> Mapping[str, float]:
-            # Builds the flat map of all variable IDs to their current values.
-            # This is the single source of truth passed to the constraints.
-
-            # Start with the initial state of all variables in the system.
-            variable_values = dict(initial_values)
-
-            # Create a dictionary of the variables the solver is currently optimizing.
-            solved_vars = {
-                var_id: independent_vars_values[i]
-                for i, var_id in enumerate(independent_vars)
-            }
-
-            # Overwrite the initial values with the current solved values.
-            variable_values.update(solved_vars)
-
-            # More sub mop up.
-            for var_id, root_id in substitution_map.items():
-                if root_id in variable_values:
-                    variable_values[var_id] = variable_values[root_id]
-
-            return variable_values
-
         def residuals_vector(independent_vars_values: np.ndarray) -> np.ndarray:
-            variable_values = build_variable_values_map(independent_vars_values)
+            variable_values = self.build_variable_values_map(
+                independent_vars_values,
+                independent_vars,
+                initial_values,
+                substitution_map,
+            )
+
             constraint_residuals = np.concatenate(
                 [c.get_residual(variable_values) for c in constraints]
             )
@@ -129,8 +108,12 @@ class Solver2DSparse(Solver2D):
             return np.concatenate([constraint_residuals, reg_residuals])
 
         def jacobian_wrapper(independent_vars_values: np.ndarray) -> csc_matrix:
-            # Use the new generic helper function.
-            variable_values = build_variable_values_map(independent_vars_values)
+            variable_values = self.build_variable_values_map(
+                independent_vars_values,
+                independent_vars,
+                initial_values,
+                substitution_map,
+            )
 
             # Original constraint Jacobian.
             jacobian = self.build_sparse_jacobian(system, var_map, variable_values)
@@ -175,8 +158,9 @@ class Solver2DSparse(Solver2D):
             verbose=2 if logger.isEnabledFor(logging.DEBUG) else 0,
         )
 
-        # Run checks and update.
-        final_variable_values = self.compute_final_variable_values(
+        # Run checks and update using the consolidated method from the base class.
+        # This effectively fanss out the final variable values through the substitution map.
+        final_variable_values = self.fan_out_solved_variable_values(
             result, independent_vars, substitution_map
         )
         self.update_primitives_from_map(final_variable_values)

--- a/src/newton/symbolic_substitution.py
+++ b/src/newton/symbolic_substitution.py
@@ -19,15 +19,14 @@ from newton.primitives import Primitive
 class SubstitutionAction(Enum):
     ELIMINATE = auto()  # Remove the constraint entirely.
     SUBSTITUTE_AND_KEEP = auto()  # Apply substitutions but keep the constraint.
-    KEEP_UNCHANGED = auto()  # No substitutions apply, keep as-is.
 
 
 @dataclass
 class SubstitutionRule:
     # Represents a variable substitution rule.
-    target_var: str  # Variable to be substituted.
-    replacement_var: str  # Variable to substitute with.
-    action: SubstitutionAction  # What to do with the constraint that created this rule.
+    target_var: str
+    replacement_var: str
+    action: SubstitutionAction
 
 
 @dataclass
@@ -46,9 +45,9 @@ class SubstitutionStats:
             return
 
         logger.debug("Symbolic substitution results:")
-        logger.debug(f"  • {self.variables_eliminated} variables eliminated")
-        logger.debug(f"  • {self.constraints_eliminated} constraints eliminated")
-        logger.debug(f"  • {self.constraints_unchanged} constraints unchanged")
+        logger.debug(f" * {self.variables_eliminated} variables eliminated")
+        logger.debug(f" * {self.constraints_eliminated} constraints eliminated")
+        logger.debug(f" * {self.constraints_unchanged} constraints unchanged")
 
 
 @dataclass
@@ -89,169 +88,127 @@ def union(var1_id: str, var2_id: str, parent_map: dict[str, str]):
             parent_map[root1] = root2
 
 
-class SymbolicSubstitution:
+def analyze_constraint(
+    constraint: Constraint,
+    index: int,
+):
     """
-    Handles symbolic substitution with clear separation between:
-    1. Rule discovery (which constraints create substitution rules).
-    2. Rule application (how to apply rules to other constraints).
-    3. Constraint filtering (which constraints to keep/eliminate).
+    Analyse a single constraint to extract substitution rules.
+    Returns list of rules this constraint creates.
     """
+    rules = []
+    constraints_to_eliminate = set()
 
-    def __init__(self):
-        self.parent_map: dict[str, str] = {}
-        self.substitution_rules: List[SubstitutionRule] = []
-        self.constraints_to_eliminate: Set[int] = set()
+    match constraint:
+        # Pure equality constraints: can be used for substitution and then skipped.
+        # --------------------------------------------------------------------------
+        case PointPointCoincident():
+            for v1, v2 in zip(
+                constraint.p1.get_variable_ids(), constraint.p2.get_variable_ids()
+            ):
+                rules.append(SubstitutionRule(v1, v2, SubstitutionAction.ELIMINATE))
 
-    def analyze_constraint(
-        self, constraint: Constraint, index: int
-    ) -> List[SubstitutionRule]:
-        """
-        Analyse a single constraint to extract substitution rules.
-        Returns list of rules this constraint creates.
-        """
-        rules = []
+            constraints_to_eliminate.add(index)
 
-        match constraint:
-            # Pure equality constraints: can be used for substitution and then skipped.
-            # --------------------------------------------------------------------------
-            case PointPointCoincident():
-                for v1, v2 in zip(
-                    constraint.p1.get_variable_ids(), constraint.p2.get_variable_ids()
-                ):
-                    rules.append(SubstitutionRule(v1, v2, SubstitutionAction.ELIMINATE))
+        case PointPointEuclideanDistance() if constraint.distance < EPS:
+            for v1, v2 in zip(
+                constraint.p1.get_variable_ids(), constraint.p2.get_variable_ids()
+            ):
+                rules.append(SubstitutionRule(v1, v2, SubstitutionAction.ELIMINATE))
 
-                self.constraints_to_eliminate.add(index)
+            constraints_to_eliminate.add(index)
 
-            case PointPointEuclideanDistance() if constraint.distance < EPS:
-                for v1, v2 in zip(
-                    constraint.p1.get_variable_ids(), constraint.p2.get_variable_ids()
-                ):
-                    rules.append(SubstitutionRule(v1, v2, SubstitutionAction.ELIMINATE))
-
-                self.constraints_to_eliminate.add(index)
-
-            # Partial equality constraints: use for substitution, but do not skip, because:
-            # - They only establish equality for some coordinates, not all.
-            # - The solver still needs the constraint equation to enforce the relationship.
-            # - They represent geometric conditions that must be maintained even after substitution.
-            # --------------------------------------------------------------------------
-            case PointPointXDistance() if constraint.distance < EPS:
-                p1_x_var = constraint.p1.get_variable_ids()[0]
-                p2_x_var = constraint.p2.get_variable_ids()[0]
-                rules.append(
-                    SubstitutionRule(
-                        p1_x_var, p2_x_var, SubstitutionAction.SUBSTITUTE_AND_KEEP
-                    )
+        # Partial equality constraints: use for substitution, but do not skip, because:
+        # - They only establish equality for some coordinates, not all.
+        # - The solver still needs the constraint equation to enforce the relationship.
+        # - They represent geometric conditions that must be maintained even after substitution.
+        # --------------------------------------------------------------------------
+        case PointPointXDistance() if constraint.distance < EPS:
+            p1_x_var = constraint.p1.get_variable_ids()[0]
+            p2_x_var = constraint.p2.get_variable_ids()[0]
+            rules.append(
+                SubstitutionRule(
+                    p1_x_var, p2_x_var, SubstitutionAction.SUBSTITUTE_AND_KEEP
                 )
-                # Don't skip.
-
-            case PointPointYDistance() if constraint.distance < EPS:
-                p1_y_var = constraint.p1.get_variable_ids()[1]
-                p2_y_var = constraint.p2.get_variable_ids()[1]
-                rules.append(
-                    SubstitutionRule(
-                        p1_y_var, p2_y_var, SubstitutionAction.SUBSTITUTE_AND_KEEP
-                    )
-                )
-                # Don't skip.
-
-            case LineHorizontal():
-                p1_y_var = constraint.line.p1.get_variable_ids()[1]
-                p2_y_var = constraint.line.p2.get_variable_ids()[1]
-                rules.append(
-                    SubstitutionRule(
-                        p1_y_var, p2_y_var, SubstitutionAction.SUBSTITUTE_AND_KEEP
-                    )
-                )
-                # Don't skip.
-
-            case LineVertical():
-                p1_x_var = constraint.line.p1.get_variable_ids()[0]
-                p2_x_var = constraint.line.p2.get_variable_ids()[0]
-                rules.append(
-                    SubstitutionRule(
-                        p1_x_var, p2_x_var, SubstitutionAction.SUBSTITUTE_AND_KEEP
-                    )
-                )
-                # Don't skip.
-
-        # TODO: Handle other constraint types.
-
-        return rules
-
-    def build_substitution_map(
-        self, constraints: Sequence[Constraint], primitives: Sequence[Primitive]
-    ) -> Dict[str, str]:
-        """
-        Build the final substitution map using union-find.
-        Returns mapping from variable_id -> canonical_variable_id.
-        """
-        # Extract all substitution rules.
-        for i, constraint in enumerate(constraints):
-            rules = self.analyze_constraint(constraint, i)
-            self.substitution_rules.extend(rules)
-
-        # Build union-find structure using the original union/find functions
-        # https://www.geeksforgeeks.org/dsa/introduction-to-disjoint-set-data-structure-or-union-find-algorithm/
-        for rule in self.substitution_rules:
-            union(rule.target_var, rule.replacement_var, self.parent_map)
-
-        # Build final substitution map
-        all_variables = self._get_all_variables(primitives)
-        substitution_map = {}
-
-        # Now build the substitution map at the variable level.
-        # For each variable, find its ultimate root/representative.
-        for var_id in all_variables:
-            root = find(var_id, self.parent_map)
-            if root != var_id:
-                substitution_map[var_id] = root
-
-        return substitution_map
-
-    def apply_substitutions(
-        self, constraints: Sequence[Constraint], primitives: Sequence[Primitive]
-    ) -> SubstitutionResults:
-        # Apply symbolic substitution and return nice, structured results.
-        substitution_map = self.build_substitution_map(constraints, primitives)
-
-        if not substitution_map:
-            logger.info("No substitutions found. Returning original constraints.")
-            return SubstitutionResults(
-                active_constraints=constraints,
-                substitution_map={},
-                constraints_eliminated=0,
-                constraints_unchanged=len(constraints),
             )
+            # Don't skip.
 
-        logger.info(f"Found {len(substitution_map)} variable substitutions to perform.")
-        logger.debug(f"Substitution map: {substitution_map}")
+        case PointPointYDistance() if constraint.distance < EPS:
+            p1_y_var = constraint.p1.get_variable_ids()[1]
+            p2_y_var = constraint.p2.get_variable_ids()[1]
+            rules.append(
+                SubstitutionRule(
+                    p1_y_var, p2_y_var, SubstitutionAction.SUBSTITUTE_AND_KEEP
+                )
+            )
+            # Don't skip.
 
-        simplified_constraints: list[Constraint] = []
+        case LineHorizontal():
+            p1_y_var = constraint.line.p1.get_variable_ids()[1]
+            p2_y_var = constraint.line.p2.get_variable_ids()[1]
+            rules.append(
+                SubstitutionRule(
+                    p1_y_var, p2_y_var, SubstitutionAction.SUBSTITUTE_AND_KEEP
+                )
+            )
+            # Don't skip.
 
-        for i, constraint in enumerate(constraints):
-            if i in self.constraints_to_eliminate:
-                logger.debug(f"Eliminating constraint {i}: {type(constraint).__name__}")
-                continue
-            simplified_constraints.append(constraint)
+        case LineVertical():
+            p1_x_var = constraint.line.p1.get_variable_ids()[0]
+            p2_x_var = constraint.line.p2.get_variable_ids()[0]
+            rules.append(
+                SubstitutionRule(
+                    p1_x_var, p2_x_var, SubstitutionAction.SUBSTITUTE_AND_KEEP
+                )
+            )
+            # Don't skip.
 
-        constraints_eliminated = len(self.constraints_to_eliminate)
-        constraints_unchanged = len(simplified_constraints)
+    # TODO: Handle other constraint types.
 
-        return SubstitutionResults(
-            active_constraints=simplified_constraints,
-            substitution_map=substitution_map,
-            constraints_eliminated=constraints_eliminated,
-            constraints_unchanged=constraints_unchanged,
-        )
-
-    def _get_all_variables(self, primitives: Sequence[Primitive]) -> Set[str]:
-        return {var_id for p in primitives for var_id in p.get_variable_ids()}
+    return rules, constraints_to_eliminate
 
 
 def perform_symbolic_substitution(
     constraints: Sequence[Constraint], primitives: Sequence[Primitive]
 ) -> SubstitutionResults:
-    substitution = SymbolicSubstitution()
-    result = substitution.apply_substitutions(constraints, primitives)
-    return result
+    substitution_rules: List[SubstitutionRule] = []
+    constraints_to_eliminate: Set[int] = set()
+    parent_map: Dict[str, str] = {}
+    stats = SubstitutionStats()
+
+    # Analyse constraints for substitution opportunities.
+    for i_constraint, constraint in enumerate(constraints):
+        _rules, _constraints_to_eliminate = analyze_constraint(constraint, i_constraint)
+        substitution_rules.extend(_rules)
+        constraints_to_eliminate.update(_constraints_to_eliminate)
+
+    # Build union-find from substitution rules.
+    for rule in substitution_rules:
+        union(rule.target_var, rule.replacement_var, parent_map)
+
+    # Build final substitution map.
+    all_vars = {var_id for p in primitives for var_id in p.get_variable_ids()}
+    substitution_map = {}
+
+    for var_id in all_vars:
+        root = find(var_id, parent_map)
+        if root != var_id:
+            substitution_map[var_id] = root
+
+    # Prune constraints.
+    simplified_constraints = [
+        c for idx, c in enumerate(constraints) if idx not in constraints_to_eliminate
+    ]
+
+    # Record stats.
+    stats.substitution_map_size = len(substitution_map)
+    stats.constraints_eliminated = len(constraints_to_eliminate)
+    stats.constraints_unchanged = len(simplified_constraints)
+    stats.variables_eliminated = len(substitution_map)
+
+    return SubstitutionResults(
+        active_constraints=simplified_constraints,
+        substitution_map=substitution_map,
+        constraints_eliminated=stats.constraints_eliminated,
+        constraints_unchanged=stats.constraints_unchanged,
+    )

--- a/src/newton/symbolic_substitution.py
+++ b/src/newton/symbolic_substitution.py
@@ -6,7 +6,6 @@ from newton.constants import EPS
 from newton.constraints import (
     Constraint,
     LineHorizontal,
-    LinesParallel,
     LineVertical,
     PointPointCoincident,
     PointPointEuclideanDistance,
@@ -14,7 +13,7 @@ from newton.constraints import (
     PointPointYDistance,
 )
 from newton.logging_config import logger
-from newton.primitives import Line, Point, Primitive
+from newton.primitives import Primitive
 
 
 class SubstitutionAction(Enum):
@@ -37,7 +36,6 @@ class SubstitutionStats:
     def __init__(self):
         self.variables_eliminated = 0
         self.constraints_eliminated = 0
-        self.constraints_rewritten = 0
         self.constraints_unchanged = 0
         self.substitution_map_size = 0
 
@@ -50,7 +48,6 @@ class SubstitutionStats:
         logger.debug("Symbolic substitution results:")
         logger.debug(f"  • {self.variables_eliminated} variables eliminated")
         logger.debug(f"  • {self.constraints_eliminated} constraints eliminated")
-        logger.debug(f"  • {self.constraints_rewritten} constraints rewritten")
         logger.debug(f"  • {self.constraints_unchanged} constraints unchanged")
 
 
@@ -60,7 +57,6 @@ class SubstitutionResults:
     active_constraints: Sequence[Constraint]
     substitution_map: Dict[str, str]
     constraints_eliminated: int
-    constraints_rewritten: int
     constraints_unchanged: int
 
 
@@ -93,91 +89,6 @@ def union(var1_id: str, var2_id: str, parent_map: dict[str, str]):
             parent_map[root1] = root2
 
 
-def get_substituted_primitive(
-    p: Primitive,
-    parent_map: dict[str, str],
-    primitive_map: dict[str, Primitive],
-) -> Primitive:
-    # Finds the single primitive that `p` has been substituted with.
-    # It's used to rewrite constraints that require a full primitive object.
-
-    # Find the root primitive ID for the first variable of p. This is our candidate
-    # for the new representative primitive.
-    variable_ids = p.get_variable_ids()
-    if not variable_ids:
-        return p
-
-    first_var_root = find(variable_ids[0], parent_map)
-    representative_prim_id = first_var_root.split("_")[0]
-
-    # Check if all other variables of p map to this same representative primitive.
-    for var_id in variable_ids[1:]:
-        root = find(var_id, parent_map)
-        prim_id = root.split("_")[0]
-        if prim_id != representative_prim_id:
-            # This is a partial substitution (e.g., only x-coords are equal).
-            # We cannot rewrite the constraint with a single new primitive, so we return
-            # the original.
-            return p
-
-    return primitive_map[representative_prim_id]
-
-
-def rewrite_constraint(
-    c: Constraint, parent_map: dict[str, str], primitive_map: dict[str, Primitive]
-) -> Constraint:
-    # Creates a new constraint object with substituted primitives.
-    match c:
-        case (
-            PointPointEuclideanDistance()
-            | PointPointXDistance()
-            | PointPointYDistance()
-        ):
-            p1_sub = get_substituted_primitive(c.p1, parent_map, primitive_map)
-            p2_sub = get_substituted_primitive(c.p2, parent_map, primitive_map)
-
-            if not isinstance(p1_sub, Point) or not isinstance(p2_sub, Point):
-                return c
-
-            return type(c)(p1=p1_sub, p2=p2_sub, distance=c.distance)
-
-        case LineHorizontal() | LineVertical():
-            p1_sub = get_substituted_primitive(c.line.p1, parent_map, primitive_map)
-            p2_sub = get_substituted_primitive(c.line.p2, parent_map, primitive_map)
-
-            if not isinstance(p1_sub, Point) or not isinstance(p2_sub, Point):
-                return c
-
-            new_line = Line(p1=p1_sub, p2=p2_sub, id=c.line.id)
-            return type(c)(line=new_line)
-
-        case LinesParallel():
-            l1_p1_sub = get_substituted_primitive(c.line1.p1, parent_map, primitive_map)
-            l1_p2_sub = get_substituted_primitive(c.line1.p2, parent_map, primitive_map)
-            l2_p1_sub = get_substituted_primitive(c.line2.p1, parent_map, primitive_map)
-            l2_p2_sub = get_substituted_primitive(c.line2.p2, parent_map, primitive_map)
-
-            if (
-                not isinstance(l1_p1_sub, Point)
-                or not isinstance(l1_p2_sub, Point)
-                or not isinstance(l2_p1_sub, Point)
-                or not isinstance(l2_p2_sub, Point)
-            ):
-                return c
-
-            new_line1 = Line(p1=l1_p1_sub, p2=l1_p2_sub, id=c.line1.id)
-            new_line2 = Line(p1=l2_p1_sub, p2=l2_p2_sub, id=c.line2.id)
-            return LinesParallel(line1=new_line1, line2=new_line2)
-
-        case _:
-            # Default case - return the original constraint
-            return c
-
-    # TODO: Add other constraint types.
-
-    return c
-
-
 class SymbolicSubstitution:
     """
     Handles symbolic substitution with clear separation between:
@@ -190,7 +101,6 @@ class SymbolicSubstitution:
         self.parent_map: dict[str, str] = {}
         self.substitution_rules: List[SubstitutionRule] = []
         self.constraints_to_eliminate: Set[int] = set()
-        self.constraints_rewritten_count = 0
 
     def analyze_constraint(
         self, constraint: Constraint, index: int
@@ -303,7 +213,6 @@ class SymbolicSubstitution:
         self, constraints: Sequence[Constraint], primitives: Sequence[Primitive]
     ) -> SubstitutionResults:
         # Apply symbolic substitution and return nice, structured results.
-        original_constraint_count = len(constraints)
         substitution_map = self.build_substitution_map(constraints, primitives)
 
         if not substitution_map:
@@ -312,49 +221,32 @@ class SymbolicSubstitution:
                 active_constraints=constraints,
                 substitution_map={},
                 constraints_eliminated=0,
-                constraints_rewritten=0,
                 constraints_unchanged=len(constraints),
             )
 
         logger.info(f"Found {len(substitution_map)} variable substitutions to perform.")
         logger.debug(f"Substitution map: {substitution_map}")
 
-        # Rewrite the constraint list using the new primitive set.
         simplified_constraints: list[Constraint] = []
-        primitive_map = {p.id: p for p in primitives}
 
         for i, constraint in enumerate(constraints):
             if i in self.constraints_to_eliminate:
                 logger.debug(f"Eliminating constraint {i}: {type(constraint).__name__}")
                 continue
+            simplified_constraints.append(constraint)
 
-            # Apply substitutions to this constraint.
-            new_constraint = rewrite_constraint(
-                constraint, self.parent_map, primitive_map
-            )
-            simplified_constraints.append(new_constraint)
-
-            # Track if this constraint was actually rewritten.
-            if new_constraint is not constraint:
-                self.constraints_rewritten_count += 1
-
-        constraints_eliminated = original_constraint_count - len(simplified_constraints)
-        constraints_unchanged = (
-            len(simplified_constraints) - self.constraints_rewritten_count
-        )
+        constraints_eliminated = len(self.constraints_to_eliminate)
+        constraints_unchanged = len(simplified_constraints)
 
         return SubstitutionResults(
             active_constraints=simplified_constraints,
             substitution_map=substitution_map,
             constraints_eliminated=constraints_eliminated,
-            constraints_rewritten=self.constraints_rewritten_count,
             constraints_unchanged=constraints_unchanged,
         )
 
     def _get_all_variables(self, primitives: Sequence[Primitive]) -> Set[str]:
-        # Get all variables from all primitives.
-        all_var_ids = {var_id for p in primitives for var_id in p.get_variable_ids()}
-        return all_var_ids
+        return {var_id for p in primitives for var_id in p.get_variable_ids()}
 
 
 def perform_symbolic_substitution(

--- a/src/newton/symbolic_substitution.py
+++ b/src/newton/symbolic_substitution.py
@@ -118,7 +118,7 @@ def analyze_constraint(
 
             constraints_to_eliminate.add(index)
 
-        # Partial equality constraints: use for substitution, but do not skip, because:
+        # Partial equality constraints, so no elimination, just substitution of variables:
         # - They only establish equality for some coordinates, not all.
         # - The solver still needs the constraint equation to enforce the relationship.
         # - They represent geometric conditions that must be maintained even after substitution.
@@ -131,7 +131,6 @@ def analyze_constraint(
                     p1_x_var, p2_x_var, SubstitutionAction.SUBSTITUTE_AND_KEEP
                 )
             )
-            # Don't skip.
 
         case PointPointYDistance() if constraint.distance < EPS:
             p1_y_var = constraint.p1.get_variable_ids()[1]
@@ -141,7 +140,6 @@ def analyze_constraint(
                     p1_y_var, p2_y_var, SubstitutionAction.SUBSTITUTE_AND_KEEP
                 )
             )
-            # Don't skip.
 
         case LineHorizontal():
             p1_y_var = constraint.line.p1.get_variable_ids()[1]
@@ -151,7 +149,6 @@ def analyze_constraint(
                     p1_y_var, p2_y_var, SubstitutionAction.SUBSTITUTE_AND_KEEP
                 )
             )
-            # Don't skip.
 
         case LineVertical():
             p1_x_var = constraint.line.p1.get_variable_ids()[0]
@@ -161,7 +158,6 @@ def analyze_constraint(
                     p1_x_var, p2_x_var, SubstitutionAction.SUBSTITUTE_AND_KEEP
                 )
             )
-            # Don't skip.
 
     # TODO: Handle other constraint types.
 

--- a/src/newton/symbolic_substitution.py
+++ b/src/newton/symbolic_substitution.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Dict, List, Set
+from typing import Dict, List, Sequence, Set
 
 from newton.constants import EPS
 from newton.constraints import (
@@ -57,7 +57,7 @@ class SubstitutionStats:
 @dataclass
 class SubstitutionResults:
     # Results from the substitution process.
-    active_constraints: List[Constraint]
+    active_constraints: Sequence[Constraint]
     substitution_map: Dict[str, str]
     constraints_eliminated: int
     constraints_rewritten: int
@@ -85,8 +85,12 @@ def union(var1_id: str, var2_id: str, parent_map: dict[str, str]):
     root2 = find(var2_id, parent_map)
 
     if root1 != root2:
-        # Simple union: make one root the parent of the other.
-        parent_map[root1] = root2
+        # Simple union: make one root the parent of the other. Choose the lexicographically
+        # smaller one as the new root for consistency.
+        if root1 < root2:
+            parent_map[root2] = root1
+        else:
+            parent_map[root1] = root2
 
 
 def get_substituted_primitive(
@@ -266,7 +270,7 @@ class SymbolicSubstitution:
         return rules
 
     def build_substitution_map(
-        self, constraints: List[Constraint], primitives: List[Primitive]
+        self, constraints: Sequence[Constraint], primitives: Sequence[Primitive]
     ) -> Dict[str, str]:
         """
         Build the final substitution map using union-find.
@@ -296,7 +300,7 @@ class SymbolicSubstitution:
         return substitution_map
 
     def apply_substitutions(
-        self, constraints: List[Constraint], primitives: List[Primitive]
+        self, constraints: Sequence[Constraint], primitives: Sequence[Primitive]
     ) -> SubstitutionResults:
         # Apply symbolic substitution and return nice, structured results.
         original_constraint_count = len(constraints)
@@ -347,14 +351,14 @@ class SymbolicSubstitution:
             constraints_unchanged=constraints_unchanged,
         )
 
-    def _get_all_variables(self, primitives: List[Primitive]) -> Set[str]:
+    def _get_all_variables(self, primitives: Sequence[Primitive]) -> Set[str]:
         # Get all variables from all primitives.
         all_var_ids = {var_id for p in primitives for var_id in p.get_variable_ids()}
         return all_var_ids
 
 
 def perform_symbolic_substitution(
-    constraints: list[Constraint], primitives: list[Primitive]
+    constraints: Sequence[Constraint], primitives: Sequence[Primitive]
 ) -> SubstitutionResults:
     substitution = SymbolicSubstitution()
     result = substitution.apply_substitutions(constraints, primitives)

--- a/src/tests/test_common_vertex.py
+++ b/src/tests/test_common_vertex.py
@@ -1,0 +1,61 @@
+import pytest
+
+from newton.constraints import (
+    LineHorizontal,
+    LinesPerpendicular,
+    PointFixed,
+    PointPointXDistance,
+    PointPointYDistance,
+)
+from newton.primitives import Line, Point
+from newton.solver_sparse import Solver2DSparse
+from newton.symbolic_substitution import perform_symbolic_substitution
+
+
+def test_perpendicular_with_shared_vertex():
+    """
+    Build a simple polyline p1-p2-p3 with two segments:
+    L1 = (p1, p2), L2 = (p2, p3)
+
+    Then constrain L1 perp L2 at the shared vertex p2.
+    """
+
+    p1 = Point(x=0.0, y=0.0, id="P1")
+    p2 = Point(x=3.2, y=0.7, id="P2")
+    p3 = Point(x=4.8, y=2.1, id="P3")
+
+    l1 = Line(p1, p2, id="L1")
+    l2 = Line(p2, p3, id="L2")
+
+    assert l1.p2 is l2.p1, "Segments must share the middle vertex"
+
+    primitives = [p1, p2, p3, l1, l2]
+
+    constraints = [
+        PointFixed(point=p1),
+        LineHorizontal(l1),
+        PointPointXDistance(p1, p2, distance=4.0),
+        PointPointYDistance(p2, p3, distance=3.0),
+        LinesPerpendicular(l1, l2),
+    ]
+
+    sub = perform_symbolic_substitution(constraints, primitives)
+
+    # Solve.
+    solver = Solver2DSparse(primitives=primitives, constraints=sub.active_constraints)
+    solver.solve()
+
+    assert p1.x == pytest.approx(0.0)
+    assert p1.y == pytest.approx(0.0)
+
+    assert p2.x == pytest.approx(4.0)
+    assert p2.y == pytest.approx(0.0)
+
+    assert p3.x == pytest.approx(4.0)
+    assert p3.y == pytest.approx(3.0)
+
+    # Check perpendicularity explicitly via dot product.
+    v1 = (p2.x - p1.x, p2.y - p1.y)
+    v2 = (p3.x - p2.x, p3.y - p2.y)
+    dot = v1[0] * v2[0] + v1[1] * v2[1]
+    assert dot == pytest.approx(0.0, abs=1e-9)

--- a/src/tests/test_substitution.py
+++ b/src/tests/test_substitution.py
@@ -1,0 +1,44 @@
+import pytest
+
+from newton.constraints import PointFixed, PointPointCoincident
+from newton.primitives import Point
+from newton.solver_dense import Solver2DDense
+from newton.symbolic_substitution import SymbolicSubstitution
+
+
+def test_substitution_without_constraint_rewriting():
+    # Define three points, two of which are coincident.
+    p1 = Point(x=0.0, y=0.0, id="P1")
+    p2 = Point(x=0.0, y=0.0, id="P2")  # Coincident with P1.
+    p3 = Point(x=5.0, y=0.0, id="P3")
+
+    # Define constraints.
+    constraints = [
+        PointPointCoincident(p1=p1, p2=p2),  # Should eliminate P2_x and P2_y.
+        PointFixed(point=p1),  # Fix P1 in place.
+    ]
+
+    primitives = [p1, p2, p3]  # P3 is unused.
+
+    # Apply symbolic substitution (no rewriting).
+    substitution = SymbolicSubstitution()
+    results = substitution.apply_substitutions(constraints, primitives)
+
+    # Verify that substitution occurred.
+    sub_map = results.substitution_map
+    assert "P2_x" in sub_map and sub_map["P2_x"].startswith("P1_")
+    assert "P2_y" in sub_map and sub_map["P2_y"].startswith("P1_")
+
+    # Constraint elimination should have occurred.
+    assert results.constraints_eliminated == 1
+    assert results.constraints_unchanged == 1
+
+    # Solve with the substituted constraints.
+    solver = Solver2DDense(
+        primitives=primitives, constraints=results.active_constraints
+    )
+    solver.solve()
+
+    # P2 should match P1 exactly due to substitution
+    assert p2.x == pytest.approx(p1.x)
+    assert p2.y == pytest.approx(p1.y)

--- a/src/tests/test_substitution.py
+++ b/src/tests/test_substitution.py
@@ -2,15 +2,15 @@ import pytest
 
 from newton.constraints import PointFixed, PointPointCoincident
 from newton.primitives import Point
-from newton.solver_dense import Solver2DDense
-from newton.symbolic_substitution import SymbolicSubstitution
+from newton.solver_sparse import Solver2DSparse
+from newton.symbolic_substitution import perform_symbolic_substitution
 
 
 def test_substitution_without_constraint_rewriting():
     # Define three points, two of which are coincident.
     p1 = Point(x=0.0, y=0.0, id="P1")
     p2 = Point(x=0.0, y=0.0, id="P2")  # Coincident with P1.
-    p3 = Point(x=5.0, y=0.0, id="P3")
+    p3 = Point(x=5.0, y=0.0, id="P3")  # Unused in constraints.
 
     # Define constraints.
     constraints = [
@@ -18,27 +18,26 @@ def test_substitution_without_constraint_rewriting():
         PointFixed(point=p1),  # Fix P1 in place.
     ]
 
-    primitives = [p1, p2, p3]  # P3 is unused.
+    primitives = [p1, p2, p3]
 
-    # Apply symbolic substitution (no rewriting).
-    substitution = SymbolicSubstitution()
-    results = substitution.apply_substitutions(constraints, primitives)
+    # Apply symbolic substitution.
+    results = perform_symbolic_substitution(constraints, primitives)
 
-    # Verify that substitution occurred.
-    sub_map = results.substitution_map
-    assert "P2_x" in sub_map and sub_map["P2_x"].startswith("P1_")
-    assert "P2_y" in sub_map and sub_map["P2_y"].startswith("P1_")
+    # Substitution map should include variable redirections for P2 -> P1
+    assert "P2_x" in results.substitution_map
+    assert "P2_y" in results.substitution_map
+    assert results.substitution_map["P2_x"].startswith("P1_")
+    assert results.substitution_map["P2_y"].startswith("P1_")
 
-    # Constraint elimination should have occurred.
+    # One constraint (coincidence) should be eliminated, one kept (fixed).
     assert results.constraints_eliminated == 1
     assert results.constraints_unchanged == 1
 
-    # Solve with the substituted constraints.
-    solver = Solver2DDense(
+    # Run solver and verify P2 follows P1
+    solver = Solver2DSparse(
         primitives=primitives, constraints=results.active_constraints
     )
     solver.solve()
 
-    # P2 should match P1 exactly due to substitution
     assert p2.x == pytest.approx(p1.x)
     assert p2.y == pytest.approx(p1.y)


### PR DESCRIPTION
This PR moves away from the possibility of rewriting constraints with fewer (i.e. substituted) primitives, instead focusing on the identification and substitution of variables.

Basically, we want to work with `P1_x`, as the actual system matrix will see, rather than working with `P1` as a whole.

Also includes some test addition and prove out of the issue raised here: https://github.com/KittyCAD/ezpz/issues/28